### PR TITLE
fix: fit all space of text area target column

### DIFF
--- a/src/components/TextTarget.tsx
+++ b/src/components/TextTarget.tsx
@@ -1,7 +1,7 @@
 export const TextTarget = () => (
   <div className="h-1/2 bg-zinc-200">
     <textarea
-      className="px-2 py-2 bg-zinc-300 text-zinc-700 h-full"
+      className="px-2 py-2 bg-zinc-300 text-zinc-700 w-full h-full"
       name="text-target"
       id="text-target"
       cols={30}


### PR DESCRIPTION
 - [x] #3 

This simple and short code fit all width of the text area to their parent

![Fix](https://github.com/Mazp17/multi-traductor/assets/85720891/39202131-e7ff-4414-9591-cd90c0ec700f)
